### PR TITLE
Add "ADX Level Browser (Unofficial)" page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # deps
 /node_modules
+deno.lock
 
 # generated content
 .source

--- a/content/install/adx-level-browser.mdx
+++ b/content/install/adx-level-browser.mdx
@@ -1,6 +1,6 @@
 ---
 title: ADX Level Browser (Unofficial)
-description: Learn how to play custom levels on AstroDX (using ADX Level Browser)
+description: Learn how to play custom levels on AstroDX (ADX Level Browser)
 ---
 
 ### Introduction
@@ -23,7 +23,7 @@ By the end of this guide, you will have installed a level to AstroDX, and AstroD
 To complete this guide, you will need:
 
 - An Android or iOS/iPadOS device with AstroDX installed. You can check [Hello, AstroDX!](/) for where to download.
-- The [ADX Level Browser](https://github.com/trustytrojan/ADX-Level-Browser) app. It works on both Android and iOS/iPadOS. Download instructions are [here](https://github.com/trustytrojan/ADX-Level-Browser/?tab=readme-ov-file#installingrunning-the-app).
+- The [ADX Level Browser](https://github.com/trustytrojan/ADX-Level-Browser) app. It works on both Android and iOS/iPadOS. [Click here for installation instructions.](https://github.com/trustytrojan/ADX-Level-Browser/?tab=readme-ov-file#installingrunning-the-app)
 
 ## How to use ADX Level Browser
 

--- a/content/install/adx-level-browser.mdx
+++ b/content/install/adx-level-browser.mdx
@@ -1,0 +1,65 @@
+---
+title: ADX Level Browser (Unofficial)
+description: Learn how to play custom levels on AstroDX (using ADX Level Browser)
+---
+
+### Introduction
+
+In this guide, you will learn how to play custom levels on **both Android and iOS/iPadOS.**
+By the end of this guide, you will have installed a level to AstroDX, and AstroDX can display it in the song select menu.
+
+[ADX Level Browser](https://github.com/trustytrojan/ADX-Level-Browser) is a community-made app to simplify the process of getting custom levels into AstroDX.
+
+### Features of ADX Level Browser
+
+- You can find levels from **multiple level sources** by adding them to the app
+- Video downloads are **optional** to save bandwidth and storage space
+- If sources provide it, displays **romanized level metadata** so you can find Japanese-titled songs or artists quickly
+- You can download and import **multiple levels at once!**
+- **[Majdata.net](https://majdata.net) is added as a default source,** so you can find levels right away!
+
+## Prerequisites
+
+To complete this guide, you will need:
+
+- An Android or iOS/iPadOS device with AstroDX installed. You can check [Hello, AstroDX!](/) for where to download.
+- The [ADX Level Browser](https://github.com/trustytrojan/ADX-Level-Browser) app. It works on both Android and iOS/iPadOS. Download instructions are [here](https://github.com/trustytrojan/ADX-Level-Browser/?tab=readme-ov-file#installingrunning-the-app).
+
+## How to use ADX Level Browser
+
+- **Tap levels** in the list after they load to select them.
+- **Pull down** on the list to refresh it. Scroll to the bottom of the list to see more levels, if available.
+- Tap the **search bar** to search for levels by their song title, song artist, or chart designer (if available).
+- Tap the **"Review Selection"** button to decide what to do with the levels you selected. From there, you can **download and/or import** your selected levels.
+- Tap the **gear icon** at the top right to open the settings menu. Here, you can manage your sources for levels.
+
+## Video Guides
+
+Check out the below videos for a more visual guide to using ADX Level Browser.
+
+### iOS Guide
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube-nocookie.com/embed/5ZvPd-g27eA"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
+></iframe>
+
+### Android Guide
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube-nocookie.com/embed/6Mto6MXSSwg"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
+></iframe>
+


### PR DESCRIPTION
This PR adds a page under the "Installing Levels" category describing how to install levels using the [ADX Level Browser](https://github.com/trustytrojan/ADX-Level-Browser) app. It uses the Android guide's structure as a base for the introduction, then goes into the specifics of the app. It has a bulleted-list descriptions of the app's features and how to use the app, as well as video guides for both Android and iOS/iPadOS for the full usage flow (select levels, download & import) of the app.

If an entirely new page is too much for you guys to accept, please let me know. My other plan is to just add a short section after the "Introduction" of the existing Android and iOS/iPadOS pages to link to the app's GitHub repository page, in which I can create my own detailed wiki.