### PR TITLE
Clarify renaming instructions for iOS devices

### DIFF
--- a/content/install/ios.mdx
+++ b/content/install/ios.mdx
@@ -61,7 +61,7 @@ You should now have a `.zip` file that AstroDX can work with, but to allow Astro
 
 Rename the `.zip` file into an `.adx` file to let AstroDX know you want to install the file as levels.
 
-If you're on a mobile device, in your file browser, long press on the `.zip` file, and find the "Rename" option to rename the file:
+On your iOS/iPadOS device, locate the ZIP file in the Files app, long press on it, and find the "Rename" option to rename the file:
 
 <Files>
     <File name="level.zip (Old)" />
@@ -69,6 +69,7 @@ If you're on a mobile device, in your file browser, long press on the `.zip` fil
 </Files>
 
 <Callout type="info">
+    For iOS/iPadOS 26.x, you can turn on "Show All Filename Extensions" from the More menu (three-dot button) → View Options or the View Options button (icon resembling four squares).
     If you can't rename the file extension, you can also rename the file to `(name).adx.zip`.
 </Callout>
 


### PR DESCRIPTION
Updated instructions for renaming the .zip file on iOS/iPadOS devices.